### PR TITLE
Fix typing error and use with earlier pythons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 schug = "schug.cli.base:cli"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.7"
 sqlmodel = "^0.0.4"
 fastapi = "^0.68.1"
 uvicorn = "^0.15.0"

--- a/src/schug/load/ensemble.py
+++ b/src/schug/load/ensemble.py
@@ -104,7 +104,7 @@ def fetch_ensembl_exon_lines(
     return fetch_ensembl_biomart(attributes=attributes, filters=filters, build=build)
 
 
-def fetch_ensembl_exons(build: str, chromosomes: Optional[list[str]] = None) -> list[EnsemblExon]:
+def fetch_ensembl_exons(build: str, chromosomes: Optional[List[str]] = None) -> List[EnsemblExon]:
     """Fetch ensembl exon objects"""
     exon_lines: EnsemblBiomartClient = fetch_ensembl_exon_lines(
         build=build, chromosomes=chromosomes

--- a/src/schug/load/gene_resources.py
+++ b/src/schug/load/gene_resources.py
@@ -11,7 +11,7 @@ HPO_URL = (
 )
 
 
-def fetch_genes_to_hpo_to_disease() -> list[str]:
+def fetch_genes_to_hpo_to_disease() -> List[str]:
     """Fetch the latest version of the map from genes to phenotypes
         Returns:
         res(list(str)): A list with the lines formatted this way:


### PR DESCRIPTION
### This PR adds | fixes:
- The server doesn't start because of some typing errors, this PR fixes them
- Server launches also using an earlier version of python (>=3.7) - Why being so strict, unless there are libs that require python >=3.9?

### How to test:
- Install and run the app locally - master branch
-  Install and run the app locally - this branch

### Expected outcome:
- [x] This branch should work to launch a server, master should return error

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
