### PR TITLE
Proxy endpoint to Ensembl exons

### DIFF
--- a/src/schug/endpoints/exons.py
+++ b/src/schug/endpoints/exons.py
@@ -1,8 +1,12 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
 from schug.database.session import get_session
+from schug.load.ensembl import fetch_ensembl_exon_lines
+from schug.load.fetch_resource import stream_resource
 from schug.models import Exon, ExonRead
+from schug.models.common import Build
 from sqlmodel import Session, select
 
 router = APIRouter()
@@ -17,3 +21,13 @@ def read_exons(
 ):
     exons = session.exec(select(Exon).offset(offset).limit(limit)).all()
     return exons
+
+
+@router.get("/ensembl_exons/", response_class=StreamingResponse)
+async def ensembl_exons(build: Build):
+    """A proxy to the Ensembl Biomart that retrieves exons in a specific genome build."""
+
+    ensembl_client: EnsemblBiomartClient = fetch_ensembl_exon_lines(build=build)
+    url: str = ensembl_client.build_url(xml=ensembl_client.xml)
+
+    return StreamingResponse(stream_resource(url), media_type="text/tsv")


### PR DESCRIPTION
### This PR adds | fixes:
- Download exons file from Ensembl using this new endpoint

### How to test:
- Launch a local server with the command  `schug serve --reload`
Download the exons in both genome builds:
- `curl -X 'GET'   'http://127.0.0.1:8000/exons/ensembl_exons/?build=37' > exons_37.tsv`
- `curl -X 'GET'   'http://127.0.0.1:8000/exons/ensembl_exons/?build=38' > exons_38.tsv`

### Expected outcome:
- [ ] Both files should be downloaded

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
