### PR TITLE
Dockerfile and docker-compose launcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM clinicalgenomics/python3.8-venv:1.0
+
+LABEL about.home="https://github.com/Clinical-Genomics/schug"
+LABEL about.license="MIT License (MIT)"
+
+# Install base dependencies
+RUN apt-get update && \
+     apt-get -y upgrade && \
+     apt-get -y install -y --no-install-recommends default-libmysqlclient-dev && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
+
+
+# make sure all messages always reach console
+ENV PYTHONUNBUFFERED=1
+
+# Create a worker user
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --create-home worker
+
+# Install and run commands from virtual environment
+RUN python3 -m venv /home/worker/venv
+ENV PATH="/home/worker/venv/bin:$PATH"
+
+# Install app
+WORKDIR /home/worker/app
+COPY --chown=worker:worker . /home/worker/app
+
+RUN pip install poetry
+RUN poetry config virtualenvs.create false
+RUN poetry install --no-interaction
+
+# Run commands as non-root
+USER worker
+
+CMD gunicorn\
+    --config gunicorn.conf.py \
+    schug.main:app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  api:
+    container_name: schug-api
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,6 @@
+bind = "0.0.0.0:8000"
+loglevel = "debug"
+threads = 4
+timeout = 400
+workers = 2
+worker_class = "uvicorn.workers.UvicornWorker"

--- a/poetry.lock
+++ b/poetry.lock
@@ -241,6 +241,27 @@ files = [
 docs = ["Sphinx"]
 
 [[package]]
+name = "gunicorn"
+version = "20.1.0"
+description = "WSGI HTTP Server for UNIX"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+]
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "h11"
 version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -788,6 +809,23 @@ idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
 idna2008 = ["idna"]
 
 [[package]]
+name = "setuptools"
+version = "67.6.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-67.6.0-py3-none-any.whl", hash = "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"},
+    {file = "setuptools-67.6.0.tar.gz", hash = "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1062,4 +1100,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "5d8e9cf440ce5ba774ddce1ba7878c79e0766a4992c5c51660b596ef20d0d915"
+content-hash = "10438bbbf111315cc1e0a5fd84c633f9859c52343fff432f97ee552029b690a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ typer = "^0.4.0"
 requests = "^2.26.0"
 aiofiles = "^23.1.0"
 httpx = "^0.23.3"
+gunicorn = "^20.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
### This PR adds | fixes:
- Creates a Dockerfile to containerize the app (fix #3)
- Creates a simple docker-compose to launch the API via gunicorn

**How to prepare for test**:
- Make sure you have Docker

### How to test:
- Run `docker-compose up`

### Expected outcome:
- In a browser, go to the app docs page:  `http://0.0.0.0:8000/docs`

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
