### PR TITLE
Fix Docker Hub prod push GitHub action

### DIFF
--- a/.github/workflows/dockerhub_prod_push.yml
+++ b/.github/workflows/dockerhub_prod_push.yml
@@ -1,22 +1,23 @@
-name: Publish to Docker Hub
+name: Publish to Docker - prod
 
 on:
- release:
-  types:
-   - created
+  release:
+    types:
+      - created
 
- docker-image-CI:
-   name: Docker Image CI
-   runs-on: ubuntu-latest
-   steps:
+jobs:
+  docker-image-CI:
+    name: Docker Image CI
+    runs-on: ubuntu-latest
+    steps:
 
-    - name: Check out git repository
-      uses: actions/checkout@v3
+      - name: Check out git repository
+        uses: actions/checkout@v3
 
-    - name: Publish main image (Dockerfile) to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v5
-      with:
-        name: clinicalgenomics/schug
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ github.event.release.tag_name }}"
+      - name: Publish main image (Dockerfile) to Registry
+        uses: elgohr/Publish-Docker-Github-Action@v5
+        with:
+          name: clinicalgenomics/schug
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest,${{ github.event.release.tag_name }}"


### PR DESCRIPTION
### This PR adds | fixes:
- The action is broken because the file is not valid, see:´here: https://github.com/Clinical-Genomics/schug/actions/runs/4405625334/workflow

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- Check if it works when you create a new release

### Expected outcome:
- [ ] Image should be pushed to Docker Hub prod

### Review:
- [x] Code approved by HS
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
