### PR TITLE
Fix a test that was going to fail

### DIFF
--- a/src/schug/main.py
+++ b/src/schug/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, status
+from schug import __version__
 
 from .endpoints import exons, genes, transcripts
 
@@ -9,7 +10,7 @@ app = FastAPI()
 
 @app.get("/")
 async def root():
-    return {"message": "Welcome to Schug: the magic gene, transcript and exon database"}
+    return {"message": f"Welcome to Schug v.{__version__}!"}
 
 
 app.include_router(

--- a/tests/test_schug.py
+++ b/tests/test_schug.py
@@ -1,5 +1,13 @@
+from fastapi import status
+from fastapi.testclient import TestClient
 from schug import __version__
 
 
-def test_version():
-    assert __version__ == '0.1.0'
+def test_root(client: TestClient):
+    """Test the root endpoint."""
+    # WHEN user makes a call to the heatbeat endpoint
+    response = client.get("/")
+    # THEN it should return success
+    assert response.status_code == status.HTTP_200_OK
+    # AND the expected message
+    assert response.json() == {"message": f"Welcome to Schug v.{__version__}!"}


### PR DESCRIPTION
### This PR adds | fixes:
- Schug version was hardcoded in a test. I have modified the / root enddpoint to show app version and I'm testing that that works instead

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
