### PR TITLE
Use memory DB as default DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+[unreleased]
+### Fixed
+- Use a memory database as default database in demo instance
+
 [1.0.0]
 ### Added
 - Endpoint to Ensembl genes download

--- a/src/schug/config.py
+++ b/src/schug/config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from pydantic import BaseSettings
 
+DEMO_DB: str = "sqlite://"
 SCHUG_PACKAGE = Path(__file__).parent
 PACKAGE_ROOT: Path = SCHUG_PACKAGE.parent
 ENV_FILE: Path = PACKAGE_ROOT / ".env"
@@ -10,8 +11,7 @@ ENV_FILE: Path = PACKAGE_ROOT / ".env"
 class Settings(BaseSettings):
     """Settings for serving the schug app"""
 
-    db_name: str = "database.db"
-    db_uri: str = "sqlite:///database.db"
+    db_uri: str = DEMO_DB
     host: str = "localhost"
     port: int = 8000
 

--- a/src/schug/database/__init__.py
+++ b/src/schug/database/__init__.py
@@ -1,7 +1,11 @@
-from sqlmodel import create_engine, SQLModel
+from schug.config import DEMO_DB, settings
+from sqlmodel import SQLModel, create_engine
 
-from schug.config import settings
+DEMO_CONNECT_ARGS: dict = {"check_same_thread": False}
 
-engine = create_engine(settings.db_uri, echo=True)
+if settings.db_uri == DEMO_DB:
+    engine = create_engine(settings.db_uri, connect_args=DEMO_CONNECT_ARGS, echo=True)
+else:
+    engine = create_engine(settings.db_uri, echo=True)
 
 SQLModel.metadata.create_all(engine)


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #30 

### How to test:
- Try to start Schug as a service in cg-vm1 and make sure it launches

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
