### PR TITLE
Fix README typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [unreleased]
+### Fixed
+- Typo in instructions to download genes in README document
+
 ## [1.2]
 ### Added
 - Include also `mane_plus_clinical` and `mane_select` columns in transcripts file downloaded from Ensembl

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Make sure [poetry][poetry] is installed
 git clone https://github.com/Clinical-Genomics/schug
 cd schug
 poetry install
-schug setup --demo
 schug serve --reload
 ```
 Go to http://localhost:8000/docs and check out the API.
@@ -39,19 +38,19 @@ Once having set up an instance of Schug, you can use the following endpoints:
 
    Downloads genes from Ensembl in text format. Specify a genome build by using the parameters `37` or `38`.
 
-   Usage: `curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=38'`
+   Usage: `curl -X 'GET' 'http://0.0.0.0:8000/genes/ensembl_genes/?build=38' > genes_GRCh38.txt`
 
  - **/transcripts/ensembl_transcripts/**
 
    Downloads gene transcripts from Ensembl in text format. Specify a genome build by using the parameters `37` or `38`.
 
-   Usage: `curl -X 'GET' 'http://0.0.0.0:8000/transcripts/ensembl_transcripts/?build=38'`
+   Usage: `curl -X 'GET' 'http://0.0.0.0:8000/transcripts/ensembl_transcripts/?build=38' > transcripts_GRCh38.txt`
 
  - **/exons/ensembl_exons/**
 
    Downloads gene exons from Ensembl in text format. Specify a genome build by using the parameters `37` or `38`.
 
-   Usage: `curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=38'`
+   Usage: `curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=38' > exons_GRCh38.txt`
 
 ## What is left to do?
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #47 -> Instructions on how to download genes

### How to test:
- Try the command using our server: `curl -X 'GET' 'schuf.scilifelab.se/genes/ensembl_genes/?build=38' > genes_GRCh38.txt`

### Expected outcome:
- [x] Genes should be downloaded in a text document

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
