### PR TITLE
Fix security issue in tj-actions/branch-names action and update version of other external images used in GitHub actions

### DIFF
--- a/.github/workflows/dockerhub_prod_push.yml
+++ b/.github/workflows/dockerhub_prod_push.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Check out git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Publish main image (Dockerfile) to Registry
         uses: elgohr/Publish-Docker-Github-Action@v5

--- a/.github/workflows/dockerhub_stage_push.yml
+++ b/.github/workflows/dockerhub_stage_push.yml
@@ -11,28 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: Check out git repository
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
 
      - name: Get branch name
        id: branch-name
-       uses: tj-actions/branch-names@v6
+       uses: tj-actions/branch-names@v7
 
      - name: Login to Docker Hub
-       uses: docker/login-action@v2
+       uses: docker/login-action@v3
        with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
 
      - name: Set up Docker Buildx
        id: buildx
-       uses: docker/setup-buildx-action@v2
+       uses: docker/setup-buildx-action@v3
 
      - name: Set up QEMU
-       uses: docker/setup-qemu-action@v2
+       uses: docker/setup-qemu-action@v3
 
      - name: Build and push
        if: steps.branch-name.outputs.is_default == 'false'
-       uses: docker/build-push-action@v4
+       uses: docker/build-push-action@v5
        with:
          context: ./
          file: ./Dockerfile

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -11,17 +11,15 @@ jobs:
   runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
-     uses: actions/checkout@v3
+     uses: actions/checkout@v4
 
    - name: Set up Python
      uses: actions/setup-python@v4
      with:
-      python-version: 3.8
+      python-version: 3.11
 
    - name: Install poetry
      uses: abatilo/actions-poetry@v2
-     with:
-      poetry-version: "1.4"
 
    - name: Build and publish to PYPI
      run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.11' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.8' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Updated Pydantic(^2.5.2) library and other dependencies
 - Support Python>=3.8
+- Updated version of external images used in GitHub actions
 
 ## [1.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change Log
 
+## [unreleased]
+### Changed
+- Updated version of external images used in GitHub actions
+
 ## [1.4]
 ### Changed
 - Updated Pydantic(^2.5.2) library and other dependencies
 - Support Python>=3.8
-- Updated version of external images used in GitHub actions
 
 ## [1.3]
 ### Fixed


### PR DESCRIPTION
### This PR adds | fixes:
- Updated external images used in GitHub actions. This is also fixing a security issue in tj-actions/branch-names <7.07 (https://github.com/tj-actions/branch-names/releases)

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
