### PR TITLE
Revert to python 3.8 in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [unreleased]
+### Fixed
+- Revert to python 3.8 in Dockerfile to avoid `RuntimeError: can't start new thread` issue
 
 ## [1.5]
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clinicalgenomics/python3.11-venv:1.0
+FROM clinicalgenomics/python3.8-venv:1.0
 
 LABEL about.home="https://github.com/Clinical-Genomics/schug"
 LABEL about.license="MIT License (MIT)"


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #64  --> The problem started when we switched to python 3.11 in the Dockerfile, see here: https://github.com/Clinical-Genomics/schug/issues/64#issuecomment-1929127010

**This is a temporary fix. In the future we should investigate what's different in python 3.11 that triggers the bug**

### How to test:
- Deploy on stage
- Locally, try to download genes with the command: ` curl -X 'GET' 'https://schug-stage.scilifelab.se/genes/ensembl_genes/?build=38'`

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
