### PR TITLE
Patch release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
-## [unreleased]
+
+## [1.5.1]
 ### Fixed
 - Revert to python 3.8 in Dockerfile to avoid `RuntimeError: can't start new thread` issue
 


### PR DESCRIPTION
## [1.5.1]
### Fixed
- Revert to python 3.8 in Dockerfile to avoid `RuntimeError: can't start new thread` issue

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
