### PR TITLE
Use Ensembl v112 to temporarily address the missing exons issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [1.6.2]
+### Fixed
+- Some exons are missing when downloading build 38 data using Ensembl v.113 (Oct 2024). Using v.112 (May 2024) until the problem is fixed. Build 37 not affected.
+
 # [1.6.1]
 ### Fixed
 - Security issue related to starlette version by updating fastapi, starlette and some dependencies

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -5,8 +5,7 @@ import requests
 
 LOG = logging.getLogger(__name__)
 BIOMART_37_URL = "https://feb2014.archive.ensembl.org/biomart/martservice?query="
-BIOMART_38_URL = "https://www.ensembl.org/biomart/martservice?query="
-
+BIOMART_38_URL = "https://may2024.archive.ensembl.org/biomart/martservice?query="
 
 class EnsemblXML:
     """Class with functions to create xml query files for ensembl biomart

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -7,6 +7,7 @@ LOG = logging.getLogger(__name__)
 BIOMART_37_URL = "https://feb2014.archive.ensembl.org/biomart/martservice?query="
 BIOMART_38_URL = "https://may2024.archive.ensembl.org/biomart/martservice?query="
 
+
 class EnsemblXML:
     """Class with functions to create xml query files for ensembl biomart
 
@@ -68,9 +69,7 @@ class EnsemblXML:
             value = filters[filter_name]
             if not isinstance(value, str):
                 value = ",".join(value)
-            formatted_lines.append(
-                f'<Filter name = "{filter_name}" value = "{value}"/>'
-            )
+            formatted_lines.append(f'<Filter name = "{filter_name}" value = "{value}"/>')
 
         return formatted_lines
 

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -69,7 +69,9 @@ class EnsemblXML:
             value = filters[filter_name]
             if not isinstance(value, str):
                 value = ",".join(value)
-            formatted_lines.append(f'<Filter name = "{filter_name}" value = "{value}"/>')
+            formatted_lines.append(
+                f'<Filter name = "{filter_name}" value = "{value}"/>'
+            )
 
         return formatted_lines
 


### PR DESCRIPTION
## Description

### Fixed
- #74 

### How to test
- Launch the server -> `schug serve --reload`
- In another terminal window, download exons in build 38 -> `curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=38' > exons_GRCh38_test.txt`

### Expected test outcome
- Make sure missing exons are present in the downloaded data -> `grep ENST00000414620 exons_GRCh38_test.txt`

## Review
- [x] Tests executed by CR, Jakob37
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
