### PR TITLE
Workaround to download all exons from the latest Ensembl BioMart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 
 # [1.6.2]
+###
+- Do not download duplicated lines from Ensembl BioMart
 ### Fixed
-- Some exons are missing when downloading build 38 data using Ensembl v.113 (Oct 2024). Using v.112 (May 2024) until the problem is fixed. Build 37 not affected.
+- Download data from Ensembl BioMart chromosome-wise, to avoid missing exons, for instance (see issue #74)
 
 # [1.6.1]
 ### Fixed

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -1,15 +1,18 @@
+import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
+from sqlmodel import Session, select
+
 from schug.database.session import get_session
-from schug.load.ensembl import fetch_ensembl_exons
+from schug.load.ensembl import CHROOMOSOMES, fetch_ensembl_exons
 from schug.load.fetch_resource import stream_resource
 from schug.models import Exon, ExonRead
 from schug.models.common import Build
-from sqlmodel import Session, select
 
 router = APIRouter()
+LOG = logging.getLogger(__name__)
 
 
 @router.get("/", response_model=List[ExonRead])
@@ -27,7 +30,10 @@ def read_exons(
 async def ensembl_exons(build: Build):
     """A proxy to the Ensembl Biomart that retrieves exons in a specific genome build."""
 
-    ensembl_client: EnsemblBiomartClient = fetch_ensembl_exons(build=build)
-    url: str = ensembl_client.build_url(xml=ensembl_client.xml)
-
-    return StreamingResponse(stream_resource(url), media_type="text/tsv")
+    for chrom in CHROOMOSOMES:
+        LOG.warning(f"Chromosome ---->{chrom}")
+        ensembl_client: EnsemblBiomartClient = fetch_ensembl_exons(
+            build=build, chromosomes=[chrom]
+        )
+        url: str = ensembl_client.build_url(xml=ensembl_client.xml)
+        return StreamingResponse(stream_resource(url), media_type="text/tsv")

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -6,13 +5,12 @@ from fastapi.responses import StreamingResponse
 from sqlmodel import Session, select
 
 from schug.database.session import get_session
-from schug.load.ensembl import CHROOMOSOMES, fetch_ensembl_exons
+from schug.load.ensembl import CHROMOSOMES, fetch_ensembl_exons
 from schug.load.fetch_resource import stream_resource
 from schug.models import Exon, ExonRead
 from schug.models.common import Build
 
 router = APIRouter()
-LOG = logging.getLogger(__name__)
 
 
 @router.get("/", response_model=List[ExonRead])
@@ -30,10 +28,17 @@ def read_exons(
 async def ensembl_exons(build: Build):
     """A proxy to the Ensembl Biomart that retrieves exons in a specific genome build."""
 
-    for chrom in CHROOMOSOMES:
-        LOG.warning(f"Chromosome ---->{chrom}")
-        ensembl_client: EnsemblBiomartClient = fetch_ensembl_exons(
-            build=build, chromosomes=[chrom]
-        )
-        url: str = ensembl_client.build_url(xml=ensembl_client.xml)
-        return StreamingResponse(stream_resource(url), media_type="text/tsv")
+    async def chromosome_stream():
+        for chrom in CHROMOSOMES:
+            print(f"Retrieving exons from chromosome: {chrom}")
+            ensembl_client: EnsemblBiomartClient = fetch_ensembl_exons(
+                build=build, chromosomes=[chrom]
+            )
+            url: str = ensembl_client.build_url(xml=ensembl_client.xml)
+
+            # Stream each chunk from the resource
+            async for chunk in stream_resource(url):
+                yield chunk
+
+    # Return the StreamingResponse with the asynchronous generator
+    return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -2,14 +2,15 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
+from sqlmodel import Session, select
+
 from schug.database.session import get_session
 from schug.load.biomart import EnsemblBiomartClient
-from schug.load.ensembl import fetch_ensembl_transcripts
+from schug.load.ensembl import CHROMOSOMES, fetch_ensembl_transcripts
 from schug.load.fetch_resource import stream_resource
 from schug.models import Transcript, TranscriptRead
 from schug.models.common import Build
 from schug.models.transcript import TranscriptReadWithExons
-from sqlmodel import Session, select
 
 router = APIRouter()
 
@@ -43,7 +44,17 @@ def read_transcript_db_id(
 async def ensembl_transcripts(build: Build):
     """A proxy to the Ensembl Biomart that retrieves transcripts in a specific genome build."""
 
-    ensembl_client: EnsemblBiomartClient = fetch_ensembl_transcripts(build=build)
-    url: str = ensembl_client.build_url(xml=ensembl_client.xml)
+    async def chromosome_stream():
+        for chrom in CHROMOSOMES:
+            print(f"Retrieving transcripts from chromosome: {chrom}")
+            ensembl_client: EnsemblBiomartClient = fetch_ensembl_transcripts(
+                build=build, chromosomes=[chrom]
+            )
+            url: str = ensembl_client.build_url(xml=ensembl_client.xml)
 
-    return StreamingResponse(stream_resource(url), media_type="text/tsv")
+            # Stream each chunk from the resource
+            async for chunk in stream_resource(url):
+                yield chunk
+
+    # Return the StreamingResponse with the asynchronous generator
+    return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -5,7 +5,7 @@ import requests
 
 LOG = logging.getLogger(__name__)
 BIOMART_37_URL = "https://feb2014.archive.ensembl.org/biomart/martservice?query="
-BIOMART_38_URL = "https://may2024.archive.ensembl.org/biomart/martservice?query="
+BIOMART_38_URL = "https://www.ensembl.org/biomart/martservice/?query="
 
 
 class EnsemblXML:
@@ -48,7 +48,7 @@ class EnsemblXML:
             '<?xml version="1.0" encoding="UTF-8"?>',
             "<!DOCTYPE Query>",
             f'<Query  virtualSchemaName = "default" formatter = "TSV" header = "{0 if bool is False else 1}" uniqueRows'
-            ' = "0" count = "" datasetConfigVersion = "0.6" completionStamp = "1">',
+            ' = "1" count = "0" datasetConfigVersion = "0.6" completionStamp = "1">',
             "",
             '\t<Dataset name = "hsapiens_gene_ensembl" interface = "default" >',
         ]

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -40,14 +40,17 @@ class EnsemblXML:
         }
 
     @staticmethod
-    def create_biomart_xml(filters: dict, attributes: List[str], header: bool) -> str:
+    def create_biomart_xml(
+        filters: dict, attributes: List[str], header: Optional[bool]
+    ) -> str:
         """Convert Ensembl Biomart query parameters into a XML format Ensembl Biomart query."""
+        LOG.warning(f"header is -->{header}")
         filter_lines: List[str] = EnsemblXML.xml_filters(filters)
         attribute_lines = EnsemblXML.xml_attributes(attributes)
         xml_lines = [
             '<?xml version="1.0" encoding="UTF-8"?>',
             "<!DOCTYPE Query>",
-            f'<Query  virtualSchemaName = "default" formatter = "TSV" header = "{0 if bool is False else 1}" uniqueRows'
+            f'<Query  virtualSchemaName = "default" formatter = "TSV" header = "{0 if header is False else 1}" uniqueRows'
             ' = "1" count = "0" datasetConfigVersion = "0.6" completionStamp = "1">',
             "",
             '\t<Dataset name = "hsapiens_gene_ensembl" interface = "default" >',

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -44,7 +44,6 @@ class EnsemblXML:
         filters: dict, attributes: List[str], header: Optional[bool]
     ) -> str:
         """Convert Ensembl Biomart query parameters into a XML format Ensembl Biomart query."""
-        LOG.warning(f"header is -->{header}")
         filter_lines: List[str] = EnsemblXML.xml_filters(filters)
         attribute_lines = EnsemblXML.xml_attributes(attributes)
         xml_lines = [

--- a/schug/load/ensembl.py
+++ b/schug/load/ensembl.py
@@ -3,6 +3,7 @@ import logging
 from typing import List, Optional
 
 from pydantic import parse_obj_as
+
 from schug.load.biomart import EnsemblBiomartClient
 from schug.models.common import Build
 from schug.models.exon import EnsemblExon
@@ -19,19 +20,14 @@ CHROMOSOMES_38 = AUTOSOMES + ["X", "Y", "M"]
 
 
 def fetch_ensembl_biomart(
-    attributes: List[str], filters: dict, build=None
+    attributes: List[str], filters: dict, build: Optional[str] = None
 ) -> EnsemblBiomartClient:
-    """Fetch data from ensembl biomart
-    Args:
-        attributes(list): List of selected attributes
-        filters(dict): Select what filters to use
-        build(str): '37' or '38'
-    Returns:
-        client(EnsemblBiomartClient)
-    """
+    """Fetch data from ensembl biomart."""
     build = build or "37"
 
-    client = EnsemblBiomartClient(build=build, filters=filters, attributes=attributes)
+    client = EnsemblBiomartClient(
+        build=build, filters=filters, attributes=attributes, header="1" in filters
+    )
     LOG.info("Selecting attributes: %s", ", ".join(attributes))
     LOG.info("Use filter: %s", filters)
 

--- a/schug/load/ensembl.py
+++ b/schug/load/ensembl.py
@@ -26,7 +26,10 @@ def fetch_ensembl_biomart(
     build = build or "37"
 
     client = EnsemblBiomartClient(
-        build=build, filters=filters, attributes=attributes, header="1" in filters
+        build=build,
+        filters=filters,
+        attributes=attributes,
+        header="1" in filters["chromosome_name"],
     )
     LOG.info("Selecting attributes: %s", ", ".join(attributes))
     LOG.info("Use filter: %s", filters)

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -6,6 +6,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
 from requests.models import Response
+
 from schug.demo import GENES_37_FILE_PATH, GENES_38_FILE_PATH
 from schug.models.common import Build
 
@@ -38,7 +39,14 @@ def test_ensembl_genes(
 
     # GIVEN a patched response from Ensembl Biomart
     gene_lines: TextIOWrapper = file_handler(path)
-    mocker.patch("schug.endpoints.genes.stream_resource", return_value=gene_lines)
+
+    async def mock_async_generator(*args, **kwargs):
+        for line in gene_lines:
+            yield line
+
+    mocker.patch(
+        "schug.endpoints.genes.stream_resource", side_effect=mock_async_generator
+    )
 
     # WHEN sending a request to Biomart to retrieve genes in the given build
     response: Response = client.get(f"{endpoints.ENSEMBL_GENES.value}?build={build}")


### PR DESCRIPTION
## Description
### Fixed
- Closes #74 
- Closes #77 

### How to test
- Start the server: `schug serve --reload`
- Download genes: `curl -X 'GET' 'http://0.0.0.0:8000/genes/ensembl_genes/?build=38' > genes_GRCh38_test.txt`
- Download transcripts: `curl -X 'GET' 'http://0.0.0.0:8000/transcripts/ensembl_transcripts/?build=38' > transcripts_GRCh38_test.txt`
- Download exons: `curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=38'` > exons_GRCh38_test.txt
- Make sure the exons from transcript ENST00000414620 are present: grep ENST00000414620 exons_GRCh38_test.txt

### Expected test outcome
- [x] Expected exons should be present

## Review
- [x] Tests executed by CR
- [x] "Merge and deploy" approved by Jakob37

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions