### PR TITLE
Deprecate Python 3.8 in Dockerfile and toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 
-# [1.6.2]
-###
+# [unreleased]
+### Changed
 - Do not download duplicated lines from Ensembl BioMart
+- Update Python version to v3.12 in Dockerfile
+- Update Python version in pyproject.toml
 ### Fixed
 - Download data from Ensembl BioMart chromosome-wise, to avoid missing exons, for instance (see issue #74)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clinicalgenomics/python3.8-venv:1.0
+FROM clinicalgenomics/python3.12-venv:1.0
 
 LABEL about.home="https://github.com/Clinical-Genomics/schug"
 LABEL about.license="MIT License (MIT)"

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,9 +22,6 @@ files = [
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
-
 [[package]]
 name = "anyio"
 version = "3.7.1"
@@ -1073,7 +1070,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -1366,5 +1362,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "8cc84e699fd483317407ef313726537a11f03ec2da0cfb1cfe03ed8906d9f4c6"
+python-versions = "^3.9"
+content-hash = "c57211fa83d53c751f19701d53aae8fdfd53db253769029680064e8b4ebd3669"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 schug = "schug.cli.base:cli"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 sqlmodel = "^0.0.14"
 fastapi = "^0.115.2"
 typer = "0.12.3"


### PR DESCRIPTION
## Description
### Changed
- Update Python version to v3.12 in Dockerfile
- Update Python version in pyproject.toml - closes #78 

### How to test
- Run docker-compose up, locally
- Create a new env with python 3.9, install and launch the server

### Expected test outcome
- Tests should be working

## Review
- [ ] Tests executed by CR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions