### PR TITLE
Do not include [success] lines in the streamed outfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-# [1.7.1]
+# [unreleased]
 ### Fixed
 - Do not include `[success]` lines in the streamed outfiles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [1.7.1]
+### Fixed
+- Do not include `[success]` lines in the streamed outfiles
+
 # [1.7]
 ### Changed
 - Do not download duplicated lines from Ensembl BioMart

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -118,7 +118,7 @@ async def ensembl_genes(build: Build):
 
             # Stream each chunk from the resource
             async for chunk in stream_resource(url):
-                yield chunk
+                yield chunk.replace(b"[success]\n", b"")
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -31,7 +31,7 @@ def test_ensembl_exons(
 
     async def mock_async_generator(*args, **kwargs):
         for line in exons_lines:
-            yield line
+            yield line.encode("utf-8")
 
     mocker.patch(
         "schug.endpoints.exons.stream_resource", side_effect=mock_async_generator

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -42,7 +42,7 @@ def test_ensembl_genes(
 
     async def mock_async_generator(*args, **kwargs):
         for line in gene_lines:
-            yield line
+            yield line.encode("utf-8")
 
     mocker.patch(
         "schug.endpoints.genes.stream_resource", side_effect=mock_async_generator

--- a/tests/endpoints/test_endpoints_transcripts.py
+++ b/tests/endpoints/test_endpoints_transcripts.py
@@ -32,7 +32,7 @@ def test_ensembl_transcripts_37(
 
     async def mock_async_generator(*args, **kwargs):
         for line in tx_lines:
-            yield line
+            yield line.encode("utf-8")
 
     mocker.patch(
         "schug.endpoints.transcripts.stream_resource", side_effect=mock_async_generator


### PR DESCRIPTION
## Description
### Fixed
- fix #82 

### How to test
- Launch the server: `schug serve`
- Download genes in build 37: `curl -X 'GET' 'http://0.0.0.0:8000/genes/ensembl_genes/?build=37' > genes_GRCh37_fixed.txt`

### Expected test outcome
- Downloaded file should not contain lines with [success]

## Review
- [x] Tests executed by CR

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
