### PR TITLE
Remove old code and apply fix also to transcripts and exons downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 # [unreleased]
 ### Changed
 - Use custom issue and pull request templates in this repository
+- Remove old code once used for downloading data from Ensembl
 ### Fixed
-- Do not include `[success]` lines in the streamed outfiles
+- Do not include `[success]` lines in the streamed outfiles: genes, transcripts and exons
 
 # [1.7]
 ### Changed

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -38,7 +38,7 @@ async def ensembl_exons(build: Build):
 
             # Stream each chunk from the resource
             async for chunk in stream_resource(url):
-                yield chunk
+                yield chunk.replace(b"[success]\n", b"")
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -54,7 +54,7 @@ async def ensembl_transcripts(build: Build):
 
             # Stream each chunk from the resource
             async for chunk in stream_resource(url):
-                yield chunk
+                yield chunk.replace(b"[success]\n", b"")
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -117,48 +117,7 @@ class EnsemblBiomartClient:
         )
 
         LOG.info("Setting up ensembl biomart client with server %s", self.server)
-        self.query = self._query_service(xml=self.xml)
-
+        
     def build_url(self, xml: str):
         """Build a query url"""
         return "".join([self.server, xml])
-
-    def _query_service(self, xml: str):
-        """Query the Ensembl biomart service and yield the resulting lines
-        Accepts:
-            xml(str): an xml formatted query, as described here:
-                https://grch37.ensembl.org/info/data/biomart/biomart_perl_api.html
-            filters(dict): A dictionary w
-               attributes(list): A list with attributes to use
-            Yields:
-                biomartline
-        """
-
-        url = self.build_url(xml)
-        try:
-            with requests.get(url, stream=True) as req:
-                for line in req.iter_lines():
-                    yield line.decode("utf-8")
-        except Exception as ex:
-            LOG.info("Error downloading data from biomart: %s", ex)
-            raise ex
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        success = False
-        if self.header:
-            self.header = False
-            return self.xml_creator.create_header(self.attributes)
-
-        line = next(self.query)
-        if line.startswith("["):
-            if "success" in line:
-                success = True
-            if not success:
-                raise SyntaxError("ensembl request is incomplete")
-            raise StopIteration
-        if not line:
-            raise StopIteration
-        return line

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -117,7 +117,7 @@ class EnsemblBiomartClient:
         )
 
         LOG.info("Setting up ensembl biomart client with server %s", self.server)
-        
+
     def build_url(self, xml: str):
         """Build a query url"""
         return "".join([self.server, xml])


### PR DESCRIPTION
## Description
- Do not include `[success]` lines in the streamed outfiles: transcripts and exons (genes was already fixed)
- Remove old code 

### How to test
- Automatic tests

### Expected test outcome
- All tests should pass

## Review
- [x] Tests executed by GitHub actions

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions