### PR TITLE
Added retry logic to stream_resource to handle failed chunk downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [unreleased]
+### Changed
+- Added retry logic to stream_resource to handle failed chunk downloads with a configurable number of attempts and error handling.
+
 # [1.8]
 ### Changed
 - Use custom issue and pull request templates in this repository

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Once having set up an instance of Schug, you can use the following endpoints:
 
    Usage: `curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=38' > exons_GRCh38.txt`
 
+## Issues While Downloading Genes, Transcripts, or Exons
+
+You might encounter errors while downloading genes, transcripts, or exons, such as the following error:
+
+```
+httpx.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)
+```
+
+This error often occurs when the external service prematurely closes the connection during data streaming. To address this issue, you can try increasing the `max_tries` parameter in your request, which otherwise defaults to 5. Increasing the number of retries can help handle intermittent network issues or temporary interruptions from the service.
+
+Here’s an example of how to modify the request:
+
+```
+curl -X 'GET' 'http://0.0.0.0:8000/exons/ensembl_exons/?build=37&max_retries=10' > exons_GRCh37.txt`
+```
+
 ## What is left to do?
 
 The basic structure is outlined and implemented, however there are many details left to implement before

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -25,7 +25,7 @@ def read_exons(
 
 
 @router.get("/ensembl_exons/", response_class=StreamingResponse)
-async def ensembl_exons(build: Build):
+async def ensembl_exons(build: Build, max_retries: int = 5):
     """A proxy to the Ensembl Biomart that retrieves exons in a specific genome build."""
 
     async def chromosome_stream():
@@ -37,7 +37,7 @@ async def ensembl_exons(build: Build):
             url: str = ensembl_client.build_url(xml=ensembl_client.xml)
 
             # Stream each chunk from the resource
-            async for chunk in stream_resource(url):
+            async for chunk in stream_resource(url=url, max_retries=max_retries):
                 yield chunk.replace(b"[success]\n", b"")
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -105,7 +105,7 @@ def read_gene_hgnc_symbol(
 
 
 @router.get("/ensembl_genes/", response_class=StreamingResponse)
-async def ensembl_genes(build: Build):
+async def ensembl_genes(build: Build, max_retries: int = 5):
     """A proxy to the Ensembl Biomart that retrieves genes in a specific genome build."""
 
     async def chromosome_stream():
@@ -117,7 +117,7 @@ async def ensembl_genes(build: Build):
             url: str = ensembl_client.build_url(xml=ensembl_client.xml)
 
             # Stream each chunk from the resource
-            async for chunk in stream_resource(url):
+            async for chunk in stream_resource(url=url, max_retries=max_retries):
                 yield chunk.replace(b"[success]\n", b"")
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -41,7 +41,7 @@ def read_transcript_db_id(
 
 
 @router.get("/ensembl_transcripts/", response_class=StreamingResponse)
-async def ensembl_transcripts(build: Build):
+async def ensembl_transcripts(build: Build, max_retries: int = 5):
     """A proxy to the Ensembl Biomart that retrieves transcripts in a specific genome build."""
 
     async def chromosome_stream():
@@ -53,7 +53,7 @@ async def ensembl_transcripts(build: Build):
             url: str = ensembl_client.build_url(xml=ensembl_client.xml)
 
             # Stream each chunk from the resource
-            async for chunk in stream_resource(url):
+            async for chunk in stream_resource(url=url, max_retries=max_retries):
                 yield chunk.replace(b"[success]\n", b"")
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/load/fetch_resource.py
+++ b/schug/load/fetch_resource.py
@@ -64,7 +64,7 @@ def fetch_resource(url: str) -> List[str]:
     return data
 
 
-async def stream_resource(url: str, max_retries: int = 5) -> AsyncGenerator:
+async def stream_resource(url: str, max_retries: int) -> AsyncGenerator:
     """Stream a file from an external service with retries for failed chunks."""
     retries = 0
     while retries < max_retries:

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -33,12 +33,10 @@ def test_ensembl_exons(
         for line in exons_lines:
             yield line.encode("utf-8")
 
-    mocker.patch(
-        "schug.endpoints.exons.stream_resource", side_effect=mock_async_generator
-    )
+    mocker.patch("schug.endpoints.exons.stream_resource", side_effect=mock_async_generator)
 
     # WHEN sending a request to Biomart to retrieve exons in the given build
-    response: Response = client.get(f"{endpoints.ENSEMBL_EXONS.value}?build={build}")
+    response: Response = client.get(f"{endpoints.ENSEMBL_EXONS.value}?build={build}&max_retries=10")
 
     # THEN it should return success
     assert response.status_code == status.HTTP_200_OK

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -33,10 +33,14 @@ def test_ensembl_exons(
         for line in exons_lines:
             yield line.encode("utf-8")
 
-    mocker.patch("schug.endpoints.exons.stream_resource", side_effect=mock_async_generator)
+    mocker.patch(
+        "schug.endpoints.exons.stream_resource", side_effect=mock_async_generator
+    )
 
     # WHEN sending a request to Biomart to retrieve exons in the given build
-    response: Response = client.get(f"{endpoints.ENSEMBL_EXONS.value}?build={build}&max_retries=10")
+    response: Response = client.get(
+        f"{endpoints.ENSEMBL_EXONS.value}?build={build}&max_retries=10"
+    )
 
     # THEN it should return success
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Description
- Retry downloading failed chunks (fix #89)

### How to test

### Expected test outcome

## Review
- [x] Tests executed by CR

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions