### PR TITLE
Additional 'Gene Biotype' col in downloaded genes file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [unreleased]
+### Added
+- An additional `Gene type` column when downloading genes to file. This allows downloading of non-coding genes
+
 # [1.9]
 ### Changed
 - Added retry logic to stream_resource to handle failed chunk downloads with a configurable number of attempts and error handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # [unreleased]
 ### Added
-- An additional `Gene type` column when downloading genes to file. This allows downloading of non-coding genes
+- An additional `Gene Biotype` column when downloading genes to file. This allows downloading of non-coding genes
 
 # [1.9]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # [unreleased]
 ### Added
-- An additional `Gene Biotype` column when downloading genes to file. This allows downloading of non-coding genes
+- An additional `Gene Biotype` (build 37) or `Gene type` (build 38) column when downloading genes to file. This allows downloading of non-coding genes
 
 # [1.9]
 ### Changed

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -37,7 +37,7 @@ class EnsemblXML:
             "end_position": "Gene end (bp)",
             "hgnc_symbol": "HGNC symbol",
             "hgnc_id": "HGNC ID",
-            "gene_type": "Gene type",
+            "gene_biotype": "Gene type",
         }
 
     @staticmethod

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -37,7 +37,7 @@ class EnsemblXML:
             "end_position": "Gene end (bp)",
             "hgnc_symbol": "HGNC symbol",
             "hgnc_id": "HGNC ID",
-            "gene_biotype": "Gene type",
+            "gene_biotype": "Gene Biotype",
         }
 
     @staticmethod

--- a/schug/load/biomart.py
+++ b/schug/load/biomart.py
@@ -37,6 +37,7 @@ class EnsemblXML:
             "end_position": "Gene end (bp)",
             "hgnc_symbol": "HGNC symbol",
             "hgnc_id": "HGNC ID",
+            "gene_type": "Gene type",
         }
 
     @staticmethod

--- a/schug/load/ensembl.py
+++ b/schug/load/ensembl.py
@@ -51,6 +51,7 @@ def fetch_ensembl_genes(
         "ensembl_gene_id",
         "hgnc_symbol",
         "hgnc_id",
+        "gene_biotype",
     ]
 
     filters = {"chromosome_name": chromosomes}


### PR DESCRIPTION
## Description
- Download coding + NON-CODING genes. Closes #95 

### How to test
- Test downloading genes (build 37 and 38 from current main):
  - curl -X 'GET' 'https://schug-stage.scilifelab.se/genes/ensembl_genes/?build=38' > genes_GRCh38_main.txt
  - curl -X 'GET' 'https://schug-stage.scilifelab.se//genes/ensembl_genes/?build=37' > genes_GRCh37_main.txt

- Deploy this branch on stage: systemctl --user stop schug.target ; systemctl --user start schug@non_coding_genes
- Test downloading genes (build 37 and 38 from this branch):
  - curl -X 'GET' 'https://schug-stage.scilifelab.se/genes/ensembl_genes/?build=38' > genes_GRCh38_featuretxt
  - curl -X 'GET' 'https://schug-stage.scilifelab.se//genes/ensembl_genes/?build=37' > genes_GRCh37_feature.txt

### Expected test outcome
- [x] The genes downloaded using this branch should be many more (about twice?) as the genes downloaded from main branch
- [x] An additional `Gene Biotype` column should be available in the genes files downloaded using this branch

## Review
- [x] Tests executed by CR

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions