### PR TITLE
Refactored downloads to avoid timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [unreleased]
+### Fixed
+- Refactor resources streaming to avoid timeout issues
+
 # [1.10]
 ### Added
 - An additional `Gene Biotype` (build 37) or `Gene type` (build 38) column when downloading genes to file. This allows downloading of non-coding genes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # [unreleased]
 ### Fixed
-- Refactor resources streaming to avoid timeout issues
+- Refactor Ensembl data downloads to avoid timeout issues
 
 # [1.10]
 ### Added

--- a/schug/cli/base.py
+++ b/schug/cli/base.py
@@ -1,5 +1,6 @@
 import typer
 import uvicorn
+
 from schug.cli import fetch, load
 from schug.config import settings
 from schug.load.demo import load_demo

--- a/schug/cli/fetch.py
+++ b/schug/cli/fetch.py
@@ -1,6 +1,7 @@
 import logging
 
 import typer
+
 from schug.load.biomart import EnsemblBiomartClient
 from schug.load.ensembl import (
     fetch_ensembl_exons,

--- a/schug/cli/load.py
+++ b/schug/cli/load.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 import typer
 from pydantic import parse_obj_as
+
 from schug.database.genes import create_gene_item
 from schug.load.ensembl import (
     fetch_ensembl_exons,

--- a/schug/database/__init__.py
+++ b/schug/database/__init__.py
@@ -1,5 +1,6 @@
-from schug.config import DEMO_DB, settings
 from sqlmodel import SQLModel, create_engine
+
+from schug.config import DEMO_DB, settings
 
 DEMO_CONNECT_ARGS: dict = {"check_same_thread": False}
 

--- a/schug/database/genes.py
+++ b/schug/database/genes.py
@@ -1,5 +1,4 @@
 from schug.database.session import get_session
-
 from schug.models.gene import EnsemblGene, Gene, into_gene
 
 

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -1,3 +1,4 @@
+import urllib.request
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -26,7 +27,7 @@ def read_exons(
 
 
 @router.get("/ensembl_exons/", response_class=StreamingResponse)
-async def ensembl_exons(build: Build, max_retries: int = 5):
+async def ensembl_exons(build: Build):
     """A proxy to the Ensembl Biomart that retrieves exons in a specific genome build."""
 
     async def chromosome_stream():
@@ -36,10 +37,10 @@ async def ensembl_exons(build: Build, max_retries: int = 5):
                 build=build, chromosomes=[chrom]
             )
             url: str = ensembl_client.build_url(xml=ensembl_client.xml)
-
-            # Stream each chunk from the resource
-            async for chunk in stream_resource(url=url, max_retries=max_retries):
-                yield chunk.replace(b"[success]\n", b"")
+            encoded_url = urllib.parse.quote(url, safe=":/?=&")
+            with urllib.request.urlopen(encoded_url) as response:
+                for line in response:
+                    yield line
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -40,6 +40,8 @@ async def ensembl_exons(build: Build):
             encoded_url = urllib.parse.quote(url, safe=":/?=&")
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
+                    if line.startswith(b"[success]"):
+                        continue
                     yield line
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -120,6 +120,8 @@ async def ensembl_genes(build: Build):
             encoded_url = urllib.parse.quote(url, safe=":/?=&")
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
+                    if line.startswith(b"[success]"):
+                        continue
                     yield line
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -1,4 +1,5 @@
 import csv
+import urllib.request
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -106,7 +107,7 @@ def read_gene_hgnc_symbol(
 
 
 @router.get("/ensembl_genes/", response_class=StreamingResponse)
-async def ensembl_genes(build: Build, max_retries: int = 5):
+async def ensembl_genes(build: Build):
     """A proxy to the Ensembl Biomart that retrieves genes in a specific genome build."""
 
     async def chromosome_stream():
@@ -116,10 +117,10 @@ async def ensembl_genes(build: Build, max_retries: int = 5):
                 build=build, chromosomes=[chrom]
             )
             url: str = ensembl_client.build_url(xml=ensembl_client.xml)
-
-            # Stream each chunk from the resource
-            async for chunk in stream_resource(url=url, max_retries=max_retries):
-                yield chunk.replace(b"[success]\n", b"")
+            encoded_url = urllib.parse.quote(url, safe=":/?=&")
+            with urllib.request.urlopen(encoded_url) as response:
+                for line in response:
+                    yield line
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -56,6 +56,8 @@ async def ensembl_transcripts(build: Build, max_retries: int = 5):
             encoded_url = urllib.parse.quote(url, safe=":/?=&")
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
+                    if line.startswith(b"[success]"):
+                        continue
                     yield line
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -1,3 +1,4 @@
+import urllib.request
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -52,10 +53,10 @@ async def ensembl_transcripts(build: Build, max_retries: int = 5):
                 build=build, chromosomes=[chrom]
             )
             url: str = ensembl_client.build_url(xml=ensembl_client.xml)
-
-            # Stream each chunk from the resource
-            async for chunk in stream_resource(url=url, max_retries=max_retries):
-                yield chunk.replace(b"[success]\n", b"")
+            encoded_url = urllib.parse.quote(url, safe=":/?=&")
+            with urllib.request.urlopen(encoded_url) as response:
+                for line in response:
+                    yield line
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/load/fetch_resource.py
+++ b/schug/load/fetch_resource.py
@@ -1,10 +1,10 @@
 import logging
+import time
 import urllib
 import zlib
 from typing import AsyncGenerator, List
 from urllib.request import urlopen
 from urllib.response import addinfourl
-import time
 
 import httpx
 import requests

--- a/schug/main.py
+++ b/schug/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, status
+
 from schug import __version__
 
 from .endpoints import exons, genes, transcripts

--- a/schug/models/__init__.py
+++ b/schug/models/__init__.py
@@ -1,3 +1,3 @@
 from .exon import Exon, ExonRead
-from .gene import Gene, GeneRead, GeneCreate, EnsemblGene, GeneReadWithTranscript
+from .gene import EnsemblGene, Gene, GeneCreate, GeneRead, GeneReadWithTranscript
 from .transcript import Transcript, TranscriptRead

--- a/schug/models/exon.py
+++ b/schug/models/exon.py
@@ -2,8 +2,9 @@ from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
-from schug.models.link_tables import ExonTranscriptLink
 from sqlmodel import Field, Relationship, SQLModel
+
+from schug.models.link_tables import ExonTranscriptLink
 
 if TYPE_CHECKING:
     from .transcript import Transcript

--- a/schug/models/transcript.py
+++ b/schug/models/transcript.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING, List, Optional
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from pydantic import field_validator
-from schug.models.exon import ExonRead
 from sqlmodel import Field, Relationship, SQLModel
+
+from schug.models.exon import ExonRead
 
 from .link_tables import ExonTranscriptLink
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,12 @@ from enum import Enum
 import pytest
 from _io import TextIOWrapper
 from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
 from schug.database.session import get_session
 from schug.main import app
 from schug.models.common import Build
 from schug.models.gene import Gene
-from sqlmodel import Session, SQLModel, create_engine
 
 TEST_DB = "sqlite:///./test.db"
 DEMO_CONNECT_ARGS = {"check_same_thread": False}
@@ -20,7 +21,7 @@ class Endpoints(str, Enum):
 
     GENES = "/genes/"
     ENSEMBL_GENES = "/genes/ensembl_genes/"
-    ENSEMBL_TRANCRIPTS = "/transcripts/ensembl_transcripts/"
+    ENSEMBL_TRANSCRIPTS = "/transcripts/ensembl_transcripts/"
     ENSEMBL_EXONS = "/exons/ensembl_exons/"
 
 

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -1,48 +1,51 @@
+import io
 from typing import Callable, Type
 
 import pytest
-from _io import TextIOWrapper
 from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
-from requests.models import Response
 
 from schug.demo import EXONS_37_FILE_PATH, EXONS_38_FILE_PATH
 from schug.models.common import Build
 
-PROXY_ENDPOINTS_PARAMS = [
-    (Build.build_37, EXONS_37_FILE_PATH),
-    (Build.build_38, EXONS_38_FILE_PATH),
-]
+genome_builds = [Build.build_37, Build.build_38]
 
 
-@pytest.mark.parametrize("build, path", PROXY_ENDPOINTS_PARAMS)
+@pytest.mark.parametrize("build", genome_builds)
 def test_ensembl_exons(
     build: str,
-    path: str,
     client: TestClient,
     endpoints: Type,
     mocker: MockerFixture,
     file_handler: Callable,
 ):
     """Test downloading the exons file in both builds using the Ensembl Biomart."""
-    # GIVEN a patched response from Ensembl Biomart
-    exons_lines: TextIOWrapper = file_handler(path)
 
-    async def mock_async_generator(*args, **kwargs):
-        for line in exons_lines:
-            yield line.encode("utf-8")
+    # GIVEN a patched response from Ensembl Biomart
+    mock_ensembl_client = mocker.MagicMock()
+    mock_ensembl_client.build_url.return_value = "http://mocked_url"
 
     mocker.patch(
-        "schug.endpoints.exons.stream_resource", side_effect=mock_async_generator
+        "schug.endpoints.exons.fetch_ensembl_exons", return_value=mock_ensembl_client
+    )
+
+    # Properly mock urlopen
+    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
+        b"mocked exon line 1\nmocked exon line 2\n"
     )
 
     # WHEN sending a request to Biomart to retrieve exons in the given build
-    response: Response = client.get(
-        f"{endpoints.ENSEMBL_EXONS.value}?build={build}&max_retries=10"
-    )
+    with client.stream(
+        "GET", f"{endpoints.ENSEMBL_EXONS.value}?build={build}"
+    ) as response:
+        assert response.status_code == status.HTTP_200_OK
 
-    # THEN it should return success
-    assert response.status_code == status.HTTP_200_OK
-    # AND response should contain lines
-    assert response.text.rsplit("\n")
+        # THEN response should contain lines
+        lines = [
+            line.strip() for line in response.iter_lines()
+        ]  # Strip newline characters
+        assert len(lines) > 0
+        assert "mocked exon line 1" in lines
+        assert "mocked exon line 2" in lines

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -24,7 +24,7 @@ def test_ensembl_exons(
 
     # GIVEN a patched response from Ensembl Biomart
     mock_ensembl_client = mocker.MagicMock()
-    mock_ensembl_client.build_url.return_value = "http://mocked_url"
+    mock_ensembl_client.build_url.return_value = "https://mocked_url"
 
     mocker.patch(
         "schug.endpoints.exons.fetch_ensembl_exons", return_value=mock_ensembl_client

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -33,7 +33,7 @@ def test_ensembl_exons(
     # Properly mock urlopen
     mock_urlopen = mocker.patch("urllib.request.urlopen")
     mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
-        b"mocked exon line 1\nmocked exon line 2\n"
+        b"mocked exon line 1\nmocked exon line 2\n[success]\n"
     )
 
     # WHEN sending a request to Biomart to retrieve exons in the given build
@@ -49,3 +49,5 @@ def test_ensembl_exons(
         assert len(lines) > 0
         assert "mocked exon line 1" in lines
         assert "mocked exon line 2" in lines
+
+        assert "[success]" not in lines

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -24,7 +24,7 @@ def test_ensembl_genes(
 
     # GIVEN a patched response from Ensembl Biomart
     mock_ensembl_client = mocker.MagicMock()
-    mock_ensembl_client.build_url.return_value = "http://mocked_url"
+    mock_ensembl_client.build_url.return_value = "https://mocked_url"
 
     mocker.patch(
         "schug.endpoints.genes.fetch_ensembl_genes", return_value=mock_ensembl_client

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -33,7 +33,7 @@ def test_ensembl_genes(
     # Properly mock urlopen
     mock_urlopen = mocker.patch("urllib.request.urlopen")
     mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
-        b"mocked gene line 1\nmocked gene line 2\n"
+        b"mocked gene line 1\nmocked gene line 2\n[success]\n"
     )
 
     # WHEN sending a request to Biomart to retrieve genes in the given build
@@ -49,3 +49,5 @@ def test_ensembl_genes(
         assert len(lines) > 0
         assert "mocked gene line 1" in lines
         assert "mocked gene line 2" in lines
+
+        assert "[success]" not in lines

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -1,35 +1,20 @@
+import io
 from typing import Callable, Type
 
 import pytest
-from _io import TextIOWrapper
 from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
-from requests.models import Response
 
-from schug.demo import GENES_37_FILE_PATH, GENES_38_FILE_PATH
+from schug.demo import EXONS_37_FILE_PATH, EXONS_38_FILE_PATH
 from schug.models.common import Build
 
-PROXY_ENDPOINTS_PARAMS = [
-    (Build.build_37, GENES_37_FILE_PATH),
-    (Build.build_38, GENES_38_FILE_PATH),
-]
+genome_builds = [Build.build_37, Build.build_38]
 
 
-def test_read_genes_empty_db(client: TestClient, endpoints: Type):
-    """Test read genes response when database is empty."""
-
-    # WHEN getting a response from the genes endpoints of an empty app
-    response = client.get(endpoints.GENES.value)
-
-    # THEN expected status should be 404 (NOT FOUND)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-@pytest.mark.parametrize("build, path", PROXY_ENDPOINTS_PARAMS)
+@pytest.mark.parametrize("build", genome_builds)
 def test_ensembl_genes(
     build: str,
-    path: str,
     client: TestClient,
     endpoints: Type,
     mocker: MockerFixture,
@@ -38,19 +23,29 @@ def test_ensembl_genes(
     """Test downloading the genes file in both builds using the Ensembl Biomart."""
 
     # GIVEN a patched response from Ensembl Biomart
-    gene_lines: TextIOWrapper = file_handler(path)
-
-    async def mock_async_generator(*args, **kwargs):
-        for line in gene_lines:
-            yield line.encode("utf-8")
+    mock_ensembl_client = mocker.MagicMock()
+    mock_ensembl_client.build_url.return_value = "http://mocked_url"
 
     mocker.patch(
-        "schug.endpoints.genes.stream_resource", side_effect=mock_async_generator
+        "schug.endpoints.genes.fetch_ensembl_genes", return_value=mock_ensembl_client
+    )
+
+    # Properly mock urlopen
+    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
+        b"mocked gene line 1\nmocked gene line 2\n"
     )
 
     # WHEN sending a request to Biomart to retrieve genes in the given build
-    response: Response = client.get(f"{endpoints.ENSEMBL_GENES.value}?build={build}")
-    # THEN it should return success
-    assert response.status_code == status.HTTP_200_OK
-    # AND response should contain lines
-    assert response.text.rsplit("\n")
+    with client.stream(
+        "GET", f"{endpoints.ENSEMBL_GENES.value}?build={build}"
+    ) as response:
+        assert response.status_code == status.HTTP_200_OK
+
+        # THEN response should contain lines
+        lines = [
+            line.strip() for line in response.iter_lines()
+        ]  # Strip newline characters
+        assert len(lines) > 0
+        assert "mocked gene line 1" in lines
+        assert "mocked gene line 2" in lines

--- a/tests/endpoints/test_endpoints_http_exceptions.py
+++ b/tests/endpoints/test_endpoints_http_exceptions.py
@@ -1,5 +1,4 @@
 import pytest
-
 from fastapi import HTTPException
 
 from schug.endpoints.http_exceptions import SchugHttpException

--- a/tests/endpoints/test_endpoints_transcripts.py
+++ b/tests/endpoints/test_endpoints_transcripts.py
@@ -24,7 +24,7 @@ def test_ensembl_transcripts(
 
     # GIVEN a patched response from Ensembl Biomart
     mock_ensembl_client = mocker.MagicMock()
-    mock_ensembl_client.build_url.return_value = "http://mocked_url"
+    mock_ensembl_client.build_url.return_value = "https://mocked_url"
 
     mocker.patch(
         "schug.endpoints.transcripts.fetch_ensembl_transcripts",

--- a/tests/endpoints/test_endpoints_transcripts.py
+++ b/tests/endpoints/test_endpoints_transcripts.py
@@ -34,7 +34,7 @@ def test_ensembl_transcripts(
     # Properly mock urlopen
     mock_urlopen = mocker.patch("urllib.request.urlopen")
     mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
-        b"mocked transcript line 1\nmocked transcript line 2\n"
+        b"mocked transcript line 1\nmocked transcript line 2\n[success]\n"
     )
 
     # WHEN sending a request to Biomart to retrieve transcripts in the given build
@@ -50,3 +50,5 @@ def test_ensembl_transcripts(
         assert len(lines) > 0
         assert "mocked transcript line 1" in lines
         assert "mocked transcript line 2" in lines
+
+        assert "[success]" not in lines

--- a/tests/endpoints/test_endpoints_transcripts.py
+++ b/tests/endpoints/test_endpoints_transcripts.py
@@ -1,48 +1,52 @@
+import io
 from typing import Callable, Type
 
 import pytest
-from _io import TextIOWrapper
 from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
-from requests.models import Response
 
-from schug.demo import TRANSCRIPTS_37_FILE_PATH, TRANSCRIPTS_38_FILE_PATH
+from schug.demo import EXONS_37_FILE_PATH, EXONS_38_FILE_PATH
 from schug.models.common import Build
 
-PROXY_ENDPOINTS_PARAMS = [
-    (Build.build_37, TRANSCRIPTS_37_FILE_PATH),
-    (Build.build_38, TRANSCRIPTS_38_FILE_PATH),
-]
+genome_builds = [Build.build_37, Build.build_38]
 
 
-@pytest.mark.parametrize("build, path", PROXY_ENDPOINTS_PARAMS)
-def test_ensembl_transcripts_37(
+@pytest.mark.parametrize("build", genome_builds)
+def test_ensembl_transcripts(
     build: str,
-    path: str,
     client: TestClient,
     endpoints: Type,
     mocker: MockerFixture,
     file_handler: Callable,
 ):
-    """Test downloading the transcripts file in both genome builds using the Ensembl Biomart."""
+    """Test downloading the transctipts file in both builds using the Ensembl Biomart."""
 
     # GIVEN a patched response from Ensembl Biomart
-    tx_lines: TextIOWrapper = file_handler(path)
-
-    async def mock_async_generator(*args, **kwargs):
-        for line in tx_lines:
-            yield line.encode("utf-8")
+    mock_ensembl_client = mocker.MagicMock()
+    mock_ensembl_client.build_url.return_value = "http://mocked_url"
 
     mocker.patch(
-        "schug.endpoints.transcripts.stream_resource", side_effect=mock_async_generator
+        "schug.endpoints.transcripts.fetch_ensembl_transcripts",
+        return_value=mock_ensembl_client,
+    )
+
+    # Properly mock urlopen
+    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
+        b"mocked transcript line 1\nmocked transcript line 2\n"
     )
 
     # WHEN sending a request to Biomart to retrieve transcripts in the given build
-    response: Response = client.get(
-        f"{endpoints.ENSEMBL_TRANCRIPTS.value}?build={build}"
-    )
-    # THEN it should return success
-    assert response.status_code == status.HTTP_200_OK
-    # AND response should contain lines
-    assert response.text.rsplit("\n")
+    with client.stream(
+        "GET", f"{endpoints.ENSEMBL_TRANSCRIPTS.value}?build={build}"
+    ) as response:
+        assert response.status_code == status.HTTP_200_OK
+
+        # THEN response should contain lines
+        lines = [
+            line.strip() for line in response.iter_lines()
+        ]  # Strip newline characters
+        assert len(lines) > 0
+        assert "mocked transcript line 1" in lines
+        assert "mocked transcript line 2" in lines

--- a/tests/test_schug.py
+++ b/tests/test_schug.py
@@ -1,5 +1,6 @@
 from fastapi import status
 from fastapi.testclient import TestClient
+
 from schug import __version__
 
 


### PR DESCRIPTION
## Description
- Avoid timeout by simplifying how resources are downloaded from Ensembl

## Review
- [x] Tests executed by CR
- [x] Tests executed by GitHub actions

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions