### PR TITLE
Reintroduce [success] lines in the streamed content, to simplify checks downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [unreleased]
+### Changed
+- Reintroduce `[success]` lines in the streamed content, to simplify checks downstream
+
 # [1.10.1]
 ### Fixed
 - Refactor Ensembl data downloads to avoid timeout issues

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -40,8 +40,6 @@ async def ensembl_exons(build: Build):
             encoded_url = urllib.parse.quote(url, safe=":/?=&")
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
-                    if line.startswith(b"[success]"):
-                        continue
                     yield line
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -120,8 +120,6 @@ async def ensembl_genes(build: Build):
             encoded_url = urllib.parse.quote(url, safe=":/?=&")
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
-                    if line.startswith(b"[success]"):
-                        continue
                     yield line
 
     # Return the StreamingResponse with the asynchronous generator

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -56,8 +56,6 @@ async def ensembl_transcripts(build: Build, max_retries: int = 5):
             encoded_url = urllib.parse.quote(url, safe=":/?=&")
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
-                    if line.startswith(b"[success]"):
-                        continue
                     yield line
 
     # Return the StreamingResponse with the asynchronous generator

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -49,5 +49,4 @@ def test_ensembl_exons(
         assert len(lines) > 0
         assert "mocked exon line 1" in lines
         assert "mocked exon line 2" in lines
-
-        assert "[success]" not in lines
+        assert "[success]" in lines

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -49,5 +49,4 @@ def test_ensembl_genes(
         assert len(lines) > 0
         assert "mocked gene line 1" in lines
         assert "mocked gene line 2" in lines
-
-        assert "[success]" not in lines
+        assert "[success]" in lines

--- a/tests/endpoints/test_endpoints_transcripts.py
+++ b/tests/endpoints/test_endpoints_transcripts.py
@@ -50,5 +50,4 @@ def test_ensembl_transcripts(
         assert len(lines) > 0
         assert "mocked transcript line 1" in lines
         assert "mocked transcript line 2" in lines
-
-        assert "[success]" not in lines
+        assert "[success]" in lines


### PR DESCRIPTION
## Description
- Re-introduce a line with [success] for each chromosome streamed successfully, this way the application can check if the downloaded data is complete

### How to test

### Expected test outcome

## Review
- [x] Tests executed by GitHub actions

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions