### PR TITLE
Sleep 5 seconds in between Biomart requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [unreleased]
+### Changed
+- Sleep 5 seconds before each Biomart request
+
 # [1.11]
 ### Changed
 - Reintroduce `[success]` lines in the streamed content, to simplify checks downstream

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 import urllib.request
 from typing import List
 
@@ -42,7 +42,7 @@ async def ensembl_exons(build: Build):
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
                     yield line
-            time.sleep(5)
+            await asyncio.sleep(5)
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/exons.py
+++ b/schug/endpoints/exons.py
@@ -1,3 +1,4 @@
+import time
 import urllib.request
 from typing import List
 
@@ -41,6 +42,7 @@ async def ensembl_exons(build: Build):
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
                     yield line
+            time.sleep(5)
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -1,4 +1,5 @@
 import csv
+import time
 import urllib.request
 from typing import List, Optional
 
@@ -121,6 +122,7 @@ async def ensembl_genes(build: Build):
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
                     yield line
+            time.sleep(5)
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/genes.py
+++ b/schug/endpoints/genes.py
@@ -1,5 +1,5 @@
+import asyncio
 import csv
-import time
 import urllib.request
 from typing import List, Optional
 
@@ -122,7 +122,7 @@ async def ensembl_genes(build: Build):
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
                     yield line
-            time.sleep(5)
+            await asyncio.sleep(5)
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -1,3 +1,4 @@
+import time
 import urllib.request
 from typing import List
 
@@ -57,6 +58,7 @@ async def ensembl_transcripts(build: Build, max_retries: int = 5):
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
                     yield line
+            time.sleep(5)
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/schug/endpoints/transcripts.py
+++ b/schug/endpoints/transcripts.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 import urllib.request
 from typing import List
 
@@ -58,7 +58,7 @@ async def ensembl_transcripts(build: Build, max_retries: int = 5):
             with urllib.request.urlopen(encoded_url) as response:
                 for line in response:
                     yield line
-            time.sleep(5)
+            await asyncio.sleep(5)
 
     # Return the StreamingResponse with the asynchronous generator
     return StreamingResponse(chromosome_stream(), media_type="text/tsv")

--- a/tests/endpoints/test_endpoint_exons.py
+++ b/tests/endpoints/test_endpoint_exons.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 from typing import Callable, Type
 
@@ -35,6 +36,8 @@ def test_ensembl_exons(
     mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
         b"mocked exon line 1\nmocked exon line 2\n[success]\n"
     )
+    # GIVEN a mocked interval between requests to Biomart
+    mocker.patch("asyncio.sleep")
 
     # WHEN sending a request to Biomart to retrieve exons in the given build
     with client.stream(

--- a/tests/endpoints/test_endpoints_genes.py
+++ b/tests/endpoints/test_endpoints_genes.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 from typing import Callable, Type
 
@@ -35,6 +36,8 @@ def test_ensembl_genes(
     mock_urlopen.return_value.__enter__.return_value = io.BytesIO(
         b"mocked gene line 1\nmocked gene line 2\n[success]\n"
     )
+    # GIVEN a mocked interval between requests to Biomart
+    mocker.patch("asyncio.sleep")
 
     # WHEN sending a request to Biomart to retrieve genes in the given build
     with client.stream(

--- a/tests/endpoints/test_endpoints_transcripts.py
+++ b/tests/endpoints/test_endpoints_transcripts.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 from typing import Callable, Type
 
@@ -30,6 +31,8 @@ def test_ensembl_transcripts(
         "schug.endpoints.transcripts.fetch_ensembl_transcripts",
         return_value=mock_ensembl_client,
     )
+    # GIVEN a mocked interval between requests to Biomart
+    mocker.patch("asyncio.sleep")
 
     # Properly mock urlopen
     mock_urlopen = mocker.patch("urllib.request.urlopen")


### PR DESCRIPTION
## Description
- Wait 5 seconds after sending a request and processing data for one chromosome

## Review
- [x] Tests executed by automatic tests

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions